### PR TITLE
Use metadataCurrent() to check if need_download_mdFile

### DIFF
--- a/axelget.py
+++ b/axelget.py
@@ -327,7 +327,7 @@ def prereposetup_hook(conduit):
 
         need_download_mdFile = True
         if os.path.exists(localMDFile):
-            if repo.withinCacheAge(localMDFile, repo.metadata_expire):
+            if repo.metadataCurrent():
                 # if md file is smaller than maxhostfileage, 
                 # don't need update it!
                 need_download_mdFile = False


### PR DESCRIPTION
Use the yumrepo metadataCurrent() to check if needs to download mdFile.
Checking withinCacheAge(localMDFile,metadata_expire) not working in some systems (centos 5) where the repomd.xml keeps the original time attributes, must use the cachecookie file, but not directly, so changed to use metadataCurrent().
